### PR TITLE
Updated for Pandas 0.18, added optional thousands separator

### DIFF
--- a/prettypandas/__init__.py
+++ b/prettypandas/__init__.py
@@ -1,4 +1,4 @@
-from .styler import apply_pretty_globals, PrettyPandas
+from .styler import apply_pretty_globals, PrettyPandas, PrettyPandasNoIndex
 
 
-__all__ = ['PrettyPandas', 'apply_pretty_globals']
+__all__ = ['PrettyPandas', 'PrettyPandasNoIndex', 'apply_pretty_globals']

--- a/prettypandas/formatters.py
+++ b/prettypandas/formatters.py
@@ -24,7 +24,7 @@ def format_number(v, number_format, prefix='', suffix='', replace_nan_with=None)
         raise TypeError("Numberic type required.")
 
 
-def as_percent(v, precision=2, scale_1_as_100_percent = True, **kwargs):
+def as_percent_with_precision(v, precision=2, scale_1_as_100_percent = True, **kwargs):
     """Convert number to percentage string.
 
     Parameters:
@@ -32,6 +32,9 @@ def as_percent(v, precision=2, scale_1_as_100_percent = True, **kwargs):
     :param v: numerical value to be converted
     :param precision: int
         decimal places to round to
+    :param scale_1_as_100_percent: boolean
+        By default the value 1 is converted to 100%.
+        Set this to False to indicate that 100 converts to 100%.
     """
     if not isinstance(precision, Integral):
         raise TypeError("Precision must be an integer.")
@@ -66,10 +69,19 @@ def as_unit(v, unit, precision=2, location='suffix', **kwargs):
 
     return formatter(v, "0.{}f".format(precision))
 
-#disable use of babel for percentages so we can control precision
-#as_percent = partial(numbers.format_percent,
-#                     locale=LOCALE_OBJ)
-#"""Format number as percentage."""
+def as_percent_babel(val, precision = None, *args, **kwargs): 
+    """Format number as percentage using babel."""
+    #n.b. swallow the precision parameter as we can't pass it to format_percent
+    return numbers.format_percent(val, locale=LOCALE_OBJ, *args, **kwargs)
+
+
+PERCENT_FORMATTERS = dict(
+    format_fn = as_percent_babel,
+    formatters = dict(
+        as_percent_babel = as_percent_babel,
+        as_percent_with_precision = as_percent_with_precision
+    )
+)
 
 def as_currency(val, replace_nan_with = None, *args, **kwargs):
     if replace_nan_with is not None and numpy.isnan(v):

--- a/prettypandas/formatters.py
+++ b/prettypandas/formatters.py
@@ -17,14 +17,12 @@ def format_number(v, number_format, prefix='', suffix='', replace_nan_with=None)
         return replace_nan_with
         
     if isinstance(v, Number):
-        return ("{{}}{{:{}}}{{}}"
-                .format(number_format)
-                .format(prefix, v, suffix))
+        return ("{}{:%s}{}" % number_format).format(prefix, v, suffix)
     else:
-        raise TypeError("Numberic type required.")
+        raise TypeError("Numeric type required.")
 
 
-def as_percent_with_precision(v, precision=2, scale_1_as_100_percent = True, **kwargs):
+def as_percent_with_precision(v, precision=2, scale_1_as_100_percent = True, replace_nan_with=None, **kwargs):
     """Convert number to percentage string.
 
     Parameters:
@@ -39,12 +37,16 @@ def as_percent_with_precision(v, precision=2, scale_1_as_100_percent = True, **k
     if not isinstance(precision, Integral):
         raise TypeError("Precision must be an integer.")
 
-    if not scale_1_as_100_percent:
-        v /= 100.0
-    return format_number(v, "0.{}%".format(precision), **kwargs)
+    if replace_nan_with is not None and numpy.isnan(v):
+        return replace_nan_with
+
+    if scale_1_as_100_percent:
+        v *= 100.0
+
+    return format_number(v, ".{}f".format(precision), suffix='%', **kwargs)
 
 
-def as_unit(v, unit, precision=2, location='suffix', **kwargs):
+def as_unit(v, unit, precision=2, location='suffix', thousands_separator = False, **kwargs):
     """Convert value to unit.
 
     Parameters:
@@ -67,7 +69,10 @@ def as_unit(v, unit, precision=2, location='suffix', **kwargs):
     else:
         raise ValueError("location must be either 'prefix' or 'suffix'.")
 
-    return formatter(v, "0.{}f".format(precision))
+    format_str = ".{}f"
+    if thousands_separator:
+        format_str = "," + format_str
+    return formatter(v, format_str.format(precision))
 
 def as_percent_babel(val, precision = None, *args, **kwargs): 
     """Format number as percentage using babel."""
@@ -84,13 +89,13 @@ PERCENT_FORMATTERS = dict(
 )
 
 def as_currency(val, replace_nan_with = None, *args, **kwargs):
-    if replace_nan_with is not None and numpy.isnan(v):
+    if replace_nan_with is not None and numpy.isnan(val):
         return replace_nan_with
     return numbers.format_currency(val, currency='USD', locale=LOCALE_OBJ)
 """Format number as currency."""
 
 
-def as_money(v, precision=2, currency='$', location='prefix'):
+def as_money(v, precision=2, currency='$', location='prefix', *args, **kwargs):
     """[DEPRECATED] Convert value to currency.
 
     Parameters:
@@ -103,7 +108,4 @@ def as_money(v, precision=2, currency='$', location='prefix'):
         'prefix' or 'suffix' representing where the currency symbol falls
         relative to the value
     """
-    warnings.warn("Depricated in favour of `as_currency`.",
-                  DeprecationWarning)
-
-    return as_unit(v, currency, precision=precision, location=location)
+    return as_unit(v, currency, precision=precision, location=location, *args, **kwargs)

--- a/prettypandas/formatters.py
+++ b/prettypandas/formatters.py
@@ -66,7 +66,7 @@ def as_unit(v, unit, precision=2, location='suffix', **kwargs):
 
     return formatter(v, "0.{}f".format(precision))
 
-#disable use of babel for percentages so we can control precision (not implemented by original author in github repo)
+#disable use of babel for percentages so we can control precision
 #as_percent = partial(numbers.format_percent,
 #                     locale=LOCALE_OBJ)
 #"""Format number as percentage."""

--- a/prettypandas/styler.py
+++ b/prettypandas/styler.py
@@ -225,7 +225,7 @@ class PrettyPandas(Styler):
         """
         return self.summary(np.min, title, **kwargs)
 
-    def as_percent(self, subset=None, precision=None, **kwargs):
+    def as_percent(self, subset=None, precision=0, **kwargs):
         """Represent subset of dataframe as percentages.
 
         Parameters:

--- a/prettypandas/styler.py
+++ b/prettypandas/styler.py
@@ -240,7 +240,7 @@ class PrettyPandas(Styler):
                                   **kwargs)
 
     @classmethod
-    def set_percent_formatter(formatter = 'as_percent_babel'):
+    def set_percent_formatter(cls, formatter = 'as_percent_babel'):
         """Set the formatting function used for percentages
 
         Parameters:


### PR DESCRIPTION
also removed deprecation warnings for as_money(), which is more flexible than the Babel as_currency() as precision and thousands separator can be controlled.
