### PR TITLE
Remove 3.3 image from travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7" # Min version supported by IPython
-  - "3.3" # Min version supported by IPython
   - "3.4"
   - "3.5"
   - "3.5-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7" # Min version supported by IPython
   - "3.4"
   - "3.5"
-  - "3.5-dev"
+  - "3.7"
 
 install:
   - "pip install -r requirements.txt"


### PR DESCRIPTION
Travis 3.3 image was failing tests due to Travis not having an image for that version of python, this PR removes it from the config.